### PR TITLE
Update Buildarr Docs (2024-04-29)

### DIFF
--- a/docs/docker/release-notes.md
+++ b/docs/docker/release-notes.md
@@ -1,5 +1,10 @@
 # Release Notes (Buildarr Docker Container)
 
+## v0.7.8 - 2024-04-29
+
+* Update the Prowlarr plugin for Buildarr to [v0.5.3](https://buildarr.github.io/plugins/prowlarr/release-notes#v053-2024-04-29)
+
+
 ## v0.7.7 - 2024-04-26
 
 * Update the Radarr plugin for Buildarr to [v0.2.6](https://buildarr.github.io/plugins/radarr/release-notes#v026-2024-04-26)

--- a/docs/installer/release-notes.md
+++ b/docs/installer/release-notes.md
@@ -1,5 +1,10 @@
 # Release Notes (Buildarr Installer for Windows)
 
+## [v0.7.8](https://github.com/buildarr/buildarr-installer/releases/tag/v0.7.8) - 2024-04-29
+
+* Update the Prowlarr plugin for Buildarr to [v0.5.3](https://buildarr.github.io/plugins/prowlarr/release-notes#v053-2024-04-29)
+
+
 ## [v0.7.7](https://github.com/buildarr/buildarr-installer/releases/tag/v0.7.7) - 2024-04-26
 
 * Update the Radarr plugin for Buildarr to [v0.2.6](https://buildarr.github.io/plugins/radarr/release-notes#v026-2024-04-26)

--- a/poetry.lock
+++ b/poetry.lock
@@ -75,7 +75,7 @@ url = "externals/buildarr-jellyseerr"
 
 [[package]]
 name = "buildarr-prowlarr"
-version = "0.5.2"
+version = "0.5.3"
 description = "Prowlarr indexer manager plugin for Buildarr"
 optional = false
 python-versions = ">=3.8,<4.0"
@@ -85,6 +85,7 @@ develop = false
 [package.dependencies]
 buildarr = ">=0.7.0,<0.8.0"
 json5 = ">=0.9.7"
+packaging = "*"
 prowlarr-py = ">=0.4.1,<0.5.0"
 
 [package.extras]


### PR DESCRIPTION
* Update the Prowlarr plugin for Buildarr to [v0.5.3](https://buildarr.github.io/plugins/prowlarr/release-notes#v053-2024-04-29)